### PR TITLE
Use php version_compare to check XOOPS version

### DIFF
--- a/class/utility.php
+++ b/class/utility.php
@@ -40,34 +40,13 @@ class XoopsfaqUtility
      */
     public static function checkVerXoops($module)
     {
-        $moduleDirName = basename(dirname(__DIR__));
-        xoops_loadLanguage('admin', $module->dirname());
-        //check for minimum XOOPS version
-        $currentVer  = substr(XOOPS_VERSION, 6); // get the numeric part of string
-        $currArray   = explode('.', $currentVer);
-        $requiredVer = '' . $module->getInfo('min_xoops'); //making sure it's a string
-        $reqArray    = explode('.', $requiredVer);
-        $success     = true;
-        foreach ($reqArray as $k => $v) {
-            if (isset($currArray[$k])) {
-                if ($currArray[$k] > $v) {
-                    break;
-                } elseif ($currArray[$k] == $v) {
-                    continue;
-                } else {
-                    $success = false;
-                    break;
-                }
-            } else {
-                if ((int)$v > 0) { // handles versions like x.x.x.0_RC2
-                    $success = false;
-                    break;
-                }
-            }
-        }
-
+        $currentVersion = strtolower(str_replace('XOOPS ', '', XOOPS_VERSION));
+        $requiredVersion = strtolower($module->getInfo('min_xoops'));
+        $vc = version_compare ($currentVersion , $requiredVersion);
+        $success = ($vc>=0);
         if (false === $success) {
-            $module->setErrors(sprintf(_AM_XOOPSFAQ_ERROR_BAD_XOOPS, $requiredVer, $currentVer));
+            xoops_loadLanguage('admin', $module->dirname());
+            $module->setErrors(sprintf(_AM_XOOPSFAQ_ERROR_BAD_XOOPS, $requiredVersion, $currentVersion));
         }
 
         return $success;


### PR DESCRIPTION
Existing code rejected XOOPS 2.5.11-Alpha1 as not meeting minimum of 2.5.9+

Currently, version_compare is used for version checks in core.